### PR TITLE
feat: log screen clicks

### DIFF
--- a/frontend/renderer.js
+++ b/frontend/renderer.js
@@ -15,7 +15,9 @@ function renderHotspot(x, y) {
     // When clicking hotspot, log the click
     div.addEventListener('click', (e) => {
         e.stopPropagation(); // Avoid event bubbling
-        window.electronAPI.sendClick({ type: 'click', x: e.clientX, y: e.clientY });
+        const coords = { type: 'click', x: e.clientX, y: e.clientY };
+        console.log('Hotspot click at', coords);
+        window.electronAPI.sendClick(coords);
     });
 
     overlay.appendChild(div);
@@ -27,7 +29,9 @@ renderHotspot(600, 500);
 
 // Capture all click events anywhere
 overlay.addEventListener('click', (e) => {
-    window.electronAPI.sendClick({ type: 'click', x: e.clientX, y: e.clientY });
+    const coords = { type: 'click', x: e.clientX, y: e.clientY };
+    console.log('Screen click at', coords);
+    window.electronAPI.sendClick(coords);
 });
 
 // Example: Send screenshot to backend


### PR DESCRIPTION
## Summary
- log hotspot clicks to console and forward via IPC
- log general screen clicks to console while forwarding to backend

## Testing
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e01b5ec80832ca97b9f16679325dc